### PR TITLE
fix: adding missing markdown code

### DIFF
--- a/src/content/reference/react-dom/server/renderToReadableStream.md
+++ b/src/content/reference/react-dom/server/renderToReadableStream.md
@@ -123,6 +123,7 @@ React inyectará el [doctype](https://developer.mozilla.org/es/docs/Glossary/Doc
   <!-- ... HTML de tus componentes ... -->
 </html>
 <script src="/main.js" async=""></script>
+```
 
 En el cliente, tu script inicial debería [hidratar el `document` entero con una llamada a `hydrateRoot`:](/reference/react-dom/client/hydrateRoot#hydrating-an-entire-document)
 


### PR DESCRIPTION
Just slipped in the last merge, the code suggestion worked wrongly