### PR TITLE
Translate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ La documentación está dividida en varias secciones con un tono y un propósito
 
 1. Sigue las instrucciones de ["Ejecución local"](#ejecución-local).
 1. Guarda los archivos y compruébalos en el navegador.
-1.  Los cambios en los componentes React en `src` se recargarán en caliente.
+1.    Los cambios en los componentes React en `src` se recargarán en caliente.
 1.  Los cambios en los archivos markdown de `content` se cargarán en caliente.
 1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Este repositorio contiene el código fuente y la documentación de [es.react.dev
 ### Instalación
 
 1. `cd es.react.dev` para entrar en la raíz del proyecto.
-2. `yarn` para instalar las dependencias npm del sitio web.
+3. `yarn` para instalar las dependencias npm del sitio web.
 
 ### Ejecución local
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ La documentación está dividida en varias secciones con un tono y un propósito
 
 1. Sigue las instrucciones de ["Ejecución local"](#ejecución-local).
 1. Guarda los archivos y compruébalos en el navegador.
-1.    Los cambios en los componentes React en `src` se recargarán en caliente.
+  1.  Los cambios en los componentes React en `src` se recargarán en caliente.
 1.  Los cambios en los archivos markdown de `content` se cargarán en caliente.
 1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ La documentación está dividida en varias secciones con un tono y un propósito
 1. Sigue las instrucciones de ["Ejecución local"](#ejecución-local).
 1. Guarda los archivos y compruébalos en el navegador.
 1.  Los cambios en los componentes React en `src` se recargarán en caliente.
-1. Los cambios en los archivos markdown de `content` se cargarán en caliente.
+1.  Los cambios en los archivos markdown de `content` se cargarán en caliente.
 1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
 
 ### Prueba el cambio

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ La documentación está dividida en varias secciones con un tono y un propósito
 
 ### Empújalo <span lang="en">(Push it)</span>
 
-1. `git add -A && git commit -m "Mi mensaje"` (sustituyendo `Mi mensaje` por un mensaje de confirmación, como `Arreglar logotipo de cabecera en Android`) para escenificar y confirmar tus cambios.
+1. `git add -A && git commit -m "Mi mensaje"` (sustituye `Mi mensaje` por un mensaje de confirmación, como `Arreglar logotipo de cabecera en Android`) para escenificar y confirmar tus cambios.
 1. `git push my-fork-name el-nombre-de-mi-rama`.
 1. Ve al [repositorio es.react.dev](https://github.com/reactjs/es.react.dev) y deberías ver las ramas empujadas recientemente.
 1. Sigue las instrucciones de GitHub.

--- a/README.md
+++ b/README.md
@@ -60,5 +60,4 @@ La documentación está dividida en varias secciones con un tono y un propósito
 Si estás interesado en traducir `es.react.dev`, consulta los esfuerzos de traducción actuales [aquí](https://github.com/reactjs/react.dev/issues/4135) (en inglés).
 
 ## Licencia
-
 El contenido enviado a [es.react.dev](https://es.react.dev/) tiene licencia CC-BY-4.0, tal y como se encuentra en el archivo [LICENSE-DOCS.md](https://github.com/reactjs/es.react.dev/blob/main/LICENSE-DOCS.md).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ La documentación está dividida en varias secciones con un tono y un propósito
 1. Sigue las instrucciones de ["Ejecución local"](#ejecución-local).
 1. Guarda los archivos y compruébalos en el navegador.
   1.  Los cambios en los componentes React en `src` se recargarán en caliente.
-1.  Los cambios en los archivos markdown de `content` se cargarán en caliente.
+  1.  Los cambios en los archivos markdown de `content` se cargarán en caliente.
 1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
 
 ### Prueba el cambio

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ La documentación está dividida en varias secciones con un tono y un propósito
 
 1. Sigue las instrucciones de ["Ejecución local"](#ejecución-local).
 1. Guarda los archivos y compruébalos en el navegador.
-1. Los cambios en los componentes React en `src` se recargarán en caliente.
+1.  Los cambios en los componentes React en `src` se recargarán en caliente.
 1. Los cambios en los archivos markdown de `content` se cargarán en caliente.
 1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ La documentación está dividida en varias secciones con un tono y un propósito
 1. Guarda los archivos y compruébalos en el navegador.
   1.  Los cambios en los componentes React en `src` se recargarán en caliente.
   1.  Los cambios en los archivos markdown de `content` se cargarán en caliente.
-1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
+  1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
 
 ### Prueba el cambio
 

--- a/README.md
+++ b/README.md
@@ -1,63 +1,64 @@
-# react.dev
+# es.react.dev
 
-This repo contains the source code and documentation powering [react.dev](https://react.dev/).
+Este repositorio contiene el código fuente y la documentación de [es.react.dev](https://es.react.dev/).
 
-## Getting started
+## Comenzar
 
-### Prerequisites
+### Prerrequisitos
 
-1. Git
-1. Node: any 12.x version starting with v12.0.0 or greater
-1. Yarn: See [Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/)
-1. A fork of the repo (for any contributions)
-1. A clone of the [react.dev repo](https://github.com/reactjs/react.dev) on your local machine
+1. Git.
+1. Node: cualquier versión 12.x a partir de v12.0.0 o superior.
+1. Yarn: consulta el [sitio web de Yarn para obtener instrucciones de instalación](https://yarnpkg.com/lang/en/docs/install/) (en inglés).
+1. Una bifurcación <span lang="en">(fork)</span> del repositorio (para cualquier contribución).
+1. Un clon <span lang="en">(clone)</span> del [repositorio es.react.dev](https://github.com/reactjs/es.react.dev) en tu máquina local.
 
-### Installation
+### Instalación
 
-1. `cd react.dev` to go into the project root
-3. `yarn` to install the website's npm dependencies
+1. `cd es.react.dev` para entrar en la raíz del proyecto.
+2. `yarn` para instalar las dependencias npm del sitio web.
 
-### Running locally
+### Ejecución local
 
-1. `yarn dev` to start the development server (powered by [Next.js](https://nextjs.org/))
-1. `open http://localhost:3000` to open the site in your favorite browser
+1. `yarn dev` para iniciar el servidor de desarrollo (desarrollado por [Next.js](https://nextjs.org/)).
+1. `open http://localhost:3000` para abrir el sitio en tu navegador favorito.
 
-## Contributing
+## Contribución
 
-### Guidelines
+### Directrices
 
-The documentation is divided into several sections with a different tone and purpose. If you plan to write more than a few sentences, you might find it helpful to get familiar with the [contributing guidelines](https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md#guidelines-for-text) for the appropriate sections.
+La documentación está dividida en varias secciones con un tono y un propósito diferentes. Si tienes previsto escribir más de unas pocas frases, quizá te resulte útil familiarizarte con las [directrices de contribución](https://github.com/reactjs/es.react.dev/blob/main/CONTRIBUTING.md#guidelines-for-text) de las secciones correspondientes.
 
-### Create a branch
+### Crear una rama <span lang="en">(branch)</span>
 
-1. `git checkout main` from any folder in your local `react.dev` repository
-1. `git pull origin main` to ensure you have the latest main code
-1. `git checkout -b the-name-of-my-branch` (replacing `the-name-of-my-branch` with a suitable name) to create a branch
+1. `git checkout main` desde cualquier carpeta de tu repositorio local `es.react.dev`.
+1. `git pull origin main` para asegurarte de que tienes el último código principal <span lang="en">(main)</span>.
+1. `git checkout -b el-nombre-de-mi-rama` (sustituyendo `el-nombre-de-mi-rama` por un nombre adecuado) para crear una rama <span lang="en">(branch)</span>.
 
-### Make the change
+### Hacer un cambio
 
-1. Follow the ["Running locally"](#running-locally) instructions
-1. Save the files and check in the browser
-  1. Changes to React components in `src` will hot-reload
-  1. Changes to markdown files in `content` will hot-reload
-  1. If working with plugins, you may need to remove the `.cache` directory and restart the server
+1. Sigue las instrucciones de ["Ejecución local"](#ejecución-local).
+1. Guarda los archivos y compruébalos en el navegador.
+1. Los cambios en los componentes React en `src` se recargarán en caliente.
+1. Los cambios en los archivos markdown de `content` se cargarán en caliente.
+1. Si trabajas con plugins, puede que tengas que eliminar el directorio `.cache` y reiniciar el servidor.
 
-### Test the change
+### Prueba el cambio
 
-1. If possible, test any visual changes in all latest versions of common browsers, on both desktop and mobile.
-2. Run `yarn check-all`. (This will run Prettier, ESLint and validate types.)
+1. Si es posible, prueba cualquier cambio visual en todas las versiones más recientes de los navegadores habituales, tanto en el escritorio como en el móvil.
+2. Ejecuta `yarn check-all`. (Esto ejecutará Prettier, ESLint y validará los tipos).
 
-### Push it
+### Empújalo <span lang="en">(Push it)</span>
 
-1. `git add -A && git commit -m "My message"` (replacing `My message` with a commit message, such as `Fix header logo on Android`) to stage and commit your changes
-1. `git push my-fork-name the-name-of-my-branch`
-1. Go to the [react.dev repo](https://github.com/reactjs/react.dev) and you should see recently pushed branches.
-1. Follow GitHub's instructions.
-1. If possible, include screenshots of visual changes. A preview build is triggered after your changes are pushed to GitHub.
+1. `git add -A && git commit -m "Mi mensaje"` (sustituyendo `Mi mensaje` por un mensaje de confirmación, como `Arreglar logotipo de cabecera en Android`) para escenificar y confirmar tus cambios.
+1. `git push my-fork-name el-nombre-de-mi-rama`.
+1. Ve al [repositorio es.react.dev](https://github.com/reactjs/es.react.dev) y deberías ver las ramas empujadas recientemente.
+1. Sigue las instrucciones de GitHub.
+1. Si es posible, incluye capturas de pantalla de los cambios visuales. Se activará una compilación de vista previa después de que tus cambios se envíen a GitHub.
 
-## Translation
+## Traducción
 
-If you are interested in translating `react.dev`, please see the current translation efforts [here](https://github.com/reactjs/react.dev/issues/4135).
+Si estás interesado en traducir `es.react.dev`, consulta los esfuerzos de traducción actuales [aquí](https://github.com/reactjs/react.dev/issues/4135) (en inglés).
 
-## License
-Content submitted to [react.dev](https://react.dev/) is CC-BY-4.0 licensed, as found in the [LICENSE-DOCS.md](https://github.com/reactjs/react.dev/blob/main/LICENSE-DOCS.md) file.
+## Licencia
+
+El contenido enviado a [es.react.dev](https://es.react.dev/) tiene licencia CC-BY-4.0, tal y como se encuentra en el archivo [LICENSE-DOCS.md](https://github.com/reactjs/es.react.dev/blob/main/LICENSE-DOCS.md).


### PR DESCRIPTION
Traducción al español, se que @gaearon en su issue https://github.com/reactjs/react.dev/issues/4135, en el apartado "What is ok to translate now?" (¿Qué se puede traducir ahora?), indica que "All pages in src/content are good to translate." (Todas las páginas en src/content son buenas para traducir.), pero eso es del 29 de noviembre de 2021 y sobre una Beta, si esta traducción no es necesaria o va en contra de las normas de traducción, por favor, desestimarla.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
