### PR TITLE
Add 'Next.js' title to installation page and fix bold marker issue

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -35,7 +35,9 @@ Si tu aplicación tiene restricciones inusuales que estos frameworks no cumplen 
 
 Estos frameworks brindan todas las características que necesitas para implementar y escalar tu aplicación en producción y están trabajando para respaldar nuestra [visión de arquitectura full-stack](#which-features-make-up-the-react-teams-full-stack-architecture-vision). Todos los frameworks que recomendamos son de código abierto, con comunidades activas que brindan soporte, y pueden ser desplegados en tu propio servidor o en un proveedor de alojamiento. Si eres autor de un framework interesado en ser incluido en esta lista, [por favor, háznoslo saber](https://github.com/reactjs/react.dev/issues/new?assignees=&labels=type%3A+framework&projects=&template=3-framework.yml&title=%5BFramework%5D%3A+).
 
-**[Next.js' (Pages Router)](https://nextjs.org/) es un framework completo de React. Es versátil y te permite crear aplicaciones React de cualquier tamaño, desde un blog mayormente estático hasta una aplicación dinámica compleja. Para crear un nuevo proyecto de Next.js, ejecuta en tu terminal:
+### Next.js {/*nextjs-pages-router*/}
+
+**[Next.js' Pages Router](https://nextjs.org/) es un framework completo de React.** Es versátil y te permite crear aplicaciones React de cualquier tamaño, desde un blog mayormente estático hasta una aplicación dinámica compleja. Para crear un nuevo proyecto de Next.js, ejecuta en tu terminal:
 
 <TerminalBlock>
 npx create-next-app@latest


### PR DESCRIPTION
Today I decided to read the React documentation in my native language and I noticed that the page: [start a new react proyect]( https://react.dev/learn/start-a-new-react-project) does not have the header title of a React framework, specifically the title of Next.js and in the Next.js part the bold markers are not closed.

So I decided to contribute and fix these 2 small points that interrupt the style of the whole page.

**Preview of the current page:**

![Screenshot Current Page](https://github.com/user-attachments/assets/ed1de282-4872-401a-8146-c866fe99d7b7)

**Preview of the new page:**

![Screenshot New Page](https://github.com/user-attachments/assets/919439d0-2150-4e12-a587-5cb6b1e32af1)
