### PR TITLE
Fix: remove broken meetup links

### DIFF
--- a/src/content/community/meetups.md
+++ b/src/content/community/meetups.md
@@ -30,15 +30,8 @@ title: Reuniones de React
 * [Bello Horizonte](https://www.meetup.com/reactbh/)
 * [Curitiba](https://www.meetup.com/pt-br/ReactJS-CWB/)
 * [Florianópolis](https://www.meetup.com/pt-br/ReactJS-Floripa/)
-* [Goiânia](https://www.meetup.com/pt-br/React-Goiania/)
 * [Joinville](https://www.meetup.com/pt-BR/React-Joinville/)
-* [Juez de Fuera](https://www.meetup.com/pt-br/React-Juiz-de-Fora/)
-* [Maringá](https://www.meetup.com/pt-BR/React-Maringa/)
-* [Porto Alegre](https://www.meetup.com/pt-BR/React-Porto-Alegre/)
-* [Rio de Janeiro](https://www.meetup.com/pt-BR/React-Rio-de-Janeiro/)
-* [Salvador](https://www.meetup.com/pt-BR/ReactSSA)
 * [San Pablo](https://www.meetup.com/pt-BR/ReactJS-SP/)
-* [Villa Vieja](https://www.meetup.com/pt-BR/React-ES/)
 
 ## Bolivia {/*bolivia*/}
 * [Bolivia](https://www.meetup.com/ReactBolivia/)
@@ -51,23 +44,12 @@ title: Reuniones de React
 * [Saskatoon, SK](https://www.meetup.com/saskatoon-react-meetup/)
 * [Toronto, ON](https://www.meetup.com/Toronto-React-Native/events/)
 
-## Chile {/*chile*/}
-* [Santiago](https://www.meetup.com/es-ES/react-santiago/)
-
-## China {/*china*/}
-* [Beijing](https://www.meetup.com/Beijing-ReactJS-Meetup/)
-
 ## Colombia {/*colombia*/}
-* [Bogotá](https://www.meetup.com/meetup-group-iHIeHykY/)
 * [Medellín](https://www.meetup.com/React-Medellin/)
-* [Cali](https://www.meetup.com/reactcali/)
 
 ## Dinamarca {/*denmark*/}
 * [Aalborg](https://www.meetup.com/Aalborg-React-React-Native-Meetup/)
 * [Aarhus](https://www.meetup.com/Aarhus-ReactJS-Meetup/)
-
-## Egipto {/*egypt*/}
-* [Cairo](https://www.meetup.com/react-cairo/)
 
 ## Inglaterra (Reino Unido) {/*england-uk*/}
 * [Manchester](https://www.meetup.com/Manchester-React-User-Group/)
@@ -76,7 +58,6 @@ title: Reuniones de React
 * [React Native London](https://guild.host/RNLDN)
 
 ## Francia {/*france*/}
-* [Nantes](https://www.meetup.com/React-Nantes/)
 * [Lila](https://www.meetup.com/ReactBeerLille/)
 * [París](https://www.meetup.com/ReactJS-Paris/)
 
@@ -92,9 +73,6 @@ title: Reuniones de React
 ## Grecia {/*greece*/}
 * [Atenas](https://www.meetup.com/React-To-React-Athens-MeetUp/)
 * [Tesalónica](https://www.meetup.com/Thessaloniki-ReactJS-Meetup/)
-
-## Hungría {/*hungary*/}
-* [Budapest](https://www.meetup.com/React-Budapest/)
 
 ## India {/*india*/}
 * [Ahmedabad](https://www.meetup.com/react-ahmedabad/)
@@ -138,12 +116,6 @@ title: Reuniones de React
 * [Karachi](https://www.facebook.com/groups/902678696597634/)
 * [Lahore](https://www.facebook.com/groups/ReactjsLahore/)
 
-## Panamá {/*panama*/}
-* [Panamá](https://www.meetup.com/React-Panama/)
-
-## Perú {/*peru*/}
-* [Lima](https://www.meetup.com/ReactJS-Peru/)
-
 ## Filipinas {/*philippines*/}
 * [Manila](https://www.meetup.com/reactjs-developers-manila/)
 * [Manila - ReactJS PH](https://www.meetup.com/ReactJS-Philippines/)
@@ -160,7 +132,6 @@ title: Reuniones de React
 
 ## España {/*spain*/}
 * [Barcelona](https://www.meetup.com/ReactJS-Barcelona/)
-* [Canarias](https://www.meetup.com/React-Canarias/)
 
 ## Suecia {/*sweden*/}
 * [Gotemburgo](https://www.meetup.com/ReactJS-Goteborg/)
@@ -176,7 +147,6 @@ title: Reuniones de React
 * [Kyiv](https://www.meetup.com/Kyiv-ReactJS-Meetup)
 
 ## Estados Unidos {/*us*/}
-* [Ann Arbor, MI - ReactJS](https://www.meetup.com/AnnArbor-jsx/)
 * [Atlanta, GA - ReactJS](https://www.meetup.com/React-ATL/)
 * [Austin, TX - ReactJS](https://www.meetup.com/ReactJS-Austin-Meetup/)
 * [Boston, MA - ReactJS](https://www.meetup.com/ReactJS-Boston/)
@@ -187,7 +157,6 @@ title: Reuniones de React
 * [Cleveland, OH - ReactJS](https://www.meetup.com/Cleveland-React/)
 * [Colón, OH - ReactJS](https://www.meetup.com/ReactJS-Columbus-meetup/)
 * [Dallas, TX - ReactJS](https://www.meetup.com/ReactDallas/)
-* [Dallas, TX - [Remoto] React JS](https://www.meetup.com/React-JS-Group/)
 * [Detroit, MI - Grupo de Usuarios de React en Detroit](https://www.meetup.com/Detroit-React-User-Group/)
 * [Indianapolis, IN - React.Indy](https://www.meetup.com/React-Indy)
 * [Irvine, CA - ReactJS](https://www.meetup.com/ReactJS-OC/)
@@ -197,27 +166,19 @@ title: Reuniones de React
 * [Los Angeles, CA - ReactJS](https://www.meetup.com/socal-react/)
 * [Los Angeles, CA - React Native](https://www.meetup.com/React-Native-Los-Angeles/)
 * [Miami, FL - ReactJS](https://www.meetup.com/React-Miami/)
-* [Nashville, TN - ReactJS](https://www.meetup.com/NashReact-Meetup/)
 * [New York, NY - ReactJS](https://www.meetup.com/NYC-Javascript-React-Group/)
 * [New York, NY - React Ladies](https://www.meetup.com/React-Ladies/)
 * [New York, NY - React Native](https://www.meetup.com/React-Native-NYC/)
 * [New York, NY - useReactNYC](https://www.meetup.com/useReactNYC/)
 * [New York, NY - React.NYC](https://guild.host/react-nyc)
-* [Omaha, NE - ReactJS/React Native](https://www.meetup.com/omaha-react-meetup-group/)
 * [Palo Alto, CA - React Native](https://www.meetup.com/React-Native-Silicon-Valley/)
-* [Philadelphia, PA - ReactJS](https://www.meetup.com/Reactadelphia/)
 * [Phoenix, AZ - ReactJS](https://www.meetup.com/ReactJS-Phoenix/)
-* [Pittsburgh, PA - ReactJS/React Native](https://www.meetup.com/ReactPgh/)
-* [Portland, OR - ReactJS](https://www.meetup.com/Portland-ReactJS/)
 * [Provo, UT - ReactJS](https://www.meetup.com/ReactJS-Utah/)
-* [Sacramento, CA - ReactJS](https://www.meetup.com/Sacramento-ReactJS-Meetup/)
 * [San Diego, CA - San Diego JS](https://www.meetup.com/sandiegojs/)
 * [San Francisco - Real World React](https://www.meetup.com/Real-World-React)
 * [San Francisco - ReactJS](https://www.meetup.com/ReactJS-San-Francisco/)
 * [San Francisco, CA - React Native](https://www.meetup.com/React-Native-San-Francisco/)
-* [San Ramon, CA - TriValley Coders](https://www.meetup.com/trivalleycoders/)
 * [Santa Monica, CA - ReactJS](https://www.meetup.com/Los-Angeles-ReactJS-User-Group/)
-* [Seattle, WA - React Native](https://www.meetup.com/Seattle-React-Native-Meetup/)
 * [Seattle, WA - ReactJS](https://www.meetup.com/seattle-react-js/)
 * [Tampa, FL - ReactJS](https://www.meetup.com/ReactJS-Tampa-Bay/)
 * [Tucson, AZ - ReactJS](https://www.meetup.com/Tucson-ReactJS-Meetup/)


### PR DESCRIPTION
I was reviewing the meetups page and noticed that there are many broken links. Several groups that were on [meetup.com](https://meetup.com/) no longer appear, possibly because they are inactive or have changed their names.

Therefore, I decided to remove those links, as they only redirected to a page like this:

![Screenshot](https://github.com/user-attachments/assets/4ddf59f3-963f-45e2-8fb1-65e83959137f)

I submitted the same changes to the documentation in English, and they were merged.

I am a native Spanish speaker so if you ever need help updating this repo I'd be happy to help. I am also a member of the **ExpressJS Organization** where I help with translation and bug fixes in the documentation.