### PR TITLE
Fix typo in Rendering Lists page

### DIFF
--- a/src/content/learn/rendering-lists.md
+++ b/src/content/learn/rendering-lists.md
@@ -415,7 +415,7 @@ Distintas fuentes de datos dan diferentes fuentes de _keys_:
 
 Imagina que los archivos de tu escritorio no tuvieran nombres. En vez de eso, tu te referirías a ellos por su orden -- el primer archivo, el segundo, y así. Podrías acostumbrarte a ello, pero una vez borres un archivo, se volvería algo confuso. El segundo archivo se convertiría en el primero, el tercer archivo se convertiría en el segundo, y así.
 
-Los nombres de archivos en una carpeta y las _keys_ JSX en un array tienen un propósito similar. Nos permiten identificar un objeto de manera única entre sus hermanos. Una _key_ bien escogida da más información aparte de la posición en el array. incluso si la _posición_ cambia devido a un reordenamiento, la _`key`_ permite a React identificar al elemento a lo largo de su ciclo de vida.
+Los nombres de archivos en una carpeta y las _keys_ JSX en un array tienen un propósito similar. Nos permiten identificar un objeto de manera única entre sus hermanos. Una _key_ bien escogida da más información aparte de la posición en el array. incluso si la _posición_ cambia debido a un reordenamiento, la _`key`_ permite a React identificar al elemento a lo largo de su ciclo de vida.
 
 <Pitfall>
 


### PR DESCRIPTION
Fix typo in 'Keeping list items in order' section of Rendering Lists page

I noticed a typographical error in the Spanish translation of the 'Renderizado de listas' page, specifically in the '¿Por qué React necesita keys? ' section. This PR corrects that typo to improve the readability and accuracy of the documentation.

Changes made:
- Corrected "devido" to "debido"

Reference:
- Real Academia Española definition: https://dle.rae.es/debido

This correction aligns the text with the official Spanish language guidelines as defined by the RAE.

This PR does not reference any existing issue.
