### PR TITLE
docs: fix typo in useCallback documentation

### DIFF
--- a/src/content/reference/react/useCallback.md
+++ b/src/content/reference/react/useCallback.md
@@ -806,7 +806,7 @@ Esto asegura que los consumidores de tu Hook puedan optimizar su propio código 
 
 ## Solución de problemas {/*troubleshooting*/}
 
-### Cada ves que mi componente se renderiza, `useCallback` devuelve una función diferente {/*every-time-my-component-renders-usecallback-returns-a-different-function*/}
+### Cada vez que mi componente se renderiza, `useCallback` devuelve una función diferente {/*every-time-my-component-renders-usecallback-returns-a-different-function*/}
 
 ¡Asegúrate de haber especificado el *array* de dependencias como un segundo argumento!
 


### PR DESCRIPTION
Esta pr solucionaria la issue: #951

before

<img width="883" alt="Captura de pantalla 2024-10-25 a las 12 59 18" src="https://github.com/user-attachments/assets/3b787d3e-3522-4dc5-aacf-63374b2b0003">

after

<img width="917" alt="image" src="https://github.com/user-attachments/assets/a35bda19-5ddc-432a-b18b-2bb5fda0504c">
