### PR TITLE
docs: fix declarative vs imperative title

### DIFF
--- a/src/content/learn/reacting-to-input-with-state.md
+++ b/src/content/learn/reacting-to-input-with-state.md
@@ -16,7 +16,7 @@ React utiliza una forma declarativa para manipular la UI. En vez de manipular tr
 
 </YouWillLearn>
 
-## Cómo la UI declarativa se compara a la declarativa {/*how-declarative-ui-compares-to-imperative*/}
+## Cómo la UI declarativa se compara a la imperativa {/*how-declarative-ui-compares-to-imperative*/}
 
 Cuando diseñas interacciones con la UI, seguramente pensarás en como la UI *cambia* en respuesta a las acciones del usuario. Imagina un formulario que permita al usuario enviar una respuesta: 
 


### PR DESCRIPTION
<!--

¡Gracias por el PR! Colaboradores como tú hacen que ¡React siga siendo increíble!

Consulte las directrices en la Guía de contribuciones:

https://github.com/reactjs/es.react.dev/blob/main/CONTRIBUTING.md

Si tu PR hace referencia a una incidencia (issue) ya existente, añade el número de incidencia a continuación

-->

En esta PR se corrige el título de la sección **_["Cómo la UI declarativa se compara a la imperativa"](https://es.react.dev/learn/reacting-to-input-with-state#how-declarative-ui-compares-to-imperative)_**.

Adjunto imágenes del estado actual del título.

En [react.dev](https://react.dev/learn/reacting-to-input-with-state#how-declarative-ui-compares-to-imperative) tenemos este título:

![image](https://github.com/user-attachments/assets/feae21f5-993f-468e-822e-ca289d2d35a6)

En la traducción de [es.react.dev](https://es.react.dev/learn/reacting-to-input-with-state#how-declarative-ui-compares-to-imperative) vemos que no hay referencia a la **"UI imperativa"** sino que se duplica la palabra _"declarativa"_:

![image](https://github.com/user-attachments/assets/3cff2c2c-1226-4174-9ff7-454ed1e10663)

---

Después del cambio aplicado en esta PR tendremos el título de la siguiente forma:

![image](https://github.com/user-attachments/assets/700f71f1-8abe-4552-9cb9-b239b81f0b77)

