### PR TITLE
fix typo in home page

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -297,7 +297,7 @@ export function HomeContent() {
                     <div className="bg-wash relative h-14 w-full" />
                     <div className="relative flex items-start justify-center flex-col flex-1 pb-16 pt-5 gap-3 px-5 lg:px-10 lg:pt-8">
                       <h4 className="leading-tight text-primary font-semibold text-3xl lg:text-4xl">
-                        Manténte fiel a la web
+                        Mantente fiel a la web
                       </h4>
                       <p className="lg:text-xl leading-normal text-secondary">
                         Las personas esperan que las páginas de las aplicaciones


### PR DESCRIPTION
Fix typo in Home page

Change made:

- Corrected "Maténte" to "Mantente"

![current](https://github.com/user-attachments/assets/849d351b-cbfa-4e35-a4dd-4f035d7a2500)

![fix](https://github.com/user-attachments/assets/a8b30919-cf86-4241-b863-e460469c48ea)


Explanation:


- "Mantén" (the imperative form of "mantener") has an accent because it is an aguda (oxytone, a word stressed on the last syllable) that ends in "n".

- When the pronoun "te" is added, the stress shifts: the resulting word "mantente" is llana (paroxytone, a word stressed on the second-to-last syllable).

- Llana words (paroxytone words) only take an accent if they do not end in a vowel, "n", or "s". Since "mantente" ends in a vowel, it should not have an accent.

That’s why "manténte" with an accent is incorrect.

[Reference to spanish orthographic rules](https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/uso-de-la-tilde/las-reglas-de-acentuaci%C3%B3n-gr%C3%A1fica/reglas-generales)

