### PR TITLE
docs: remove unnecesary english text in team.md

### DIFF
--- a/src/content/community/team.md
+++ b/src/content/community/team.md
@@ -13,7 +13,7 @@ El desarrollo de React está dirigido por un equipo dedicado que trabaja a tiemp
 Los miembros del equipo de React Core trabajan a tiempo completo en las API de componentes principales, el motor que impulsa React DOM y React Native, React DevTools y el sitio web de documentación de React.
 
 Los miembros actuales del equipo de React se enumeran en orden alfabético a continuación.
-Engineer at Meta
+
 <TeamMember name="Andrew Clark" permalink="andrew-clark" photo="/images/team/acdlite.jpg" github="acdlite" twitter="acdlite" threads="acdlite" title="Ingeniero en Vercel">
     Andrew comenzó con el desarrollo web creando sitios con WordPress, y y finalmente se engañó a sí mismo para hacer JavaScript. Su pasatiempo favorito es el karaoke. Andrew es un villano o una princesa de Disney, según el día.
 </TeamMember>


### PR DESCRIPTION
El texto "Engineer at Meta":
1. No corresponde al idioma de la documentación.
2. Esta fuera del contexto de la información.

**Antes:**

![react-es-docs-before](https://github.com/user-attachments/assets/a18a6431-fb0b-4c2c-ac91-4b3b51c2e45e)

**Después:**

![image](https://github.com/user-attachments/assets/da5b99d0-5dda-4573-90f6-069b8816d80c)


