### PR TITLE
Translate `overview` in table of contents

### DIFF
--- a/src/utils/prepareMDX.js
+++ b/src/utils/prepareMDX.js
@@ -7,7 +7,7 @@ import {Children} from 'react';
 // TODO: Esta lógica podría estar en plugins MDX en lugar de esto.
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export const PREPARE_MDX_CACHE_BREAKER = 3;
+export const PREPARE_MDX_CACHE_BREAKER = 4;
 // !!! IMPORTANT !!! Bump this if you change any logic.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -65,7 +65,7 @@ function getTableOfContents(children, depth) {
   if (anchors.length > 0) {
     anchors.unshift({
       url: '#',
-      text: 'Overview',
+      text: 'Descripción general',
       depth: 2,
     });
   }


### PR DESCRIPTION
All pages with a table of contents were displaying the `overview` word in english, this PR translates it to spanish.

- Before:
<img width="200" src="https://github.com/user-attachments/assets/3729bf0b-7f5e-4c1e-a53f-3b1bb64f19ed" />

- After
<img width="200" src="https://github.com/user-attachments/assets/8bca3f3e-b9c3-4319-8125-3755af09886a" />
